### PR TITLE
Only allow X active backups per volume

### DIFF
--- a/etc/api-server.conf-sample
+++ b/etc/api-server.conf-sample
@@ -49,6 +49,9 @@ fill_percentage_limit = 0.5
 #fill_strategy = broad_fill
 #image_convert_limit = 1
 
+[backup]
+# per_volume_limit = 100
+
 [storage]
 # node_timeout = 120
 

--- a/lunr/api/server.py
+++ b/lunr/api/server.py
@@ -41,6 +41,7 @@ class ApiWsgiApp(LunrWsgiApp):
         self.image_convert_limit = conf.int('placement',
                                             'image_convert_limit', 1)
         self.node_timeout = conf.float('storage', 'node_timeout', 120)
+        self.backups_per_volume = conf.int('backup', 'per_volume_limit', 100)
 
     def _get_helper(self, conf):
         return db.configure(conf)


### PR DESCRIPTION
Enforce a limit of the number of active backups per volume. The backup manifests use up ridiculous amounts of memory after they grow to large (1000+) sizes.