### PR TITLE
added fix for image size>127G

### DIFF
--- a/lunr/storage/helper/volume.py
+++ b/lunr/storage/helper/volume.py
@@ -516,8 +516,6 @@ class VolumeHelper(object):
                 if status.upper() != 'ACTIVE':
                     raise InvalidImage("Non-active image status: %s" % status)
                 min_disk = getattr(image, 'min_disk', 0)
-                if min_disk > 127:
-                    raise InvalidImage("Image > 127GB: %s" % image_id)
                 if min_disk:
                     multiplier = self._get_scratch_multiplier(image)
                     convert_gbs = int(min_disk * multiplier)

--- a/testlunr/unit/storage/helper/test_volume.py
+++ b/testlunr/unit/storage/helper/test_volume.py
@@ -326,22 +326,6 @@ class TestCreateFromImage(BaseHelper):
         self.assertEquals(lunr_cb.called, True)
         self.assertEquals(cinder_cb.called, True)
 
-    def test_create_from_image_too_big(self):
-        image_id = uuid4()
-        # >127 fails to convert
-        min_disk = 128
-
-        def glance_conn(conf, tenant_id, glance_urls=None):
-            image = MockImage(image_id, len('data'), 'data', min_disk=min_disk)
-            glance = MockImageGlance(image)
-            return glance
-        volume.get_glance_conn = glance_conn
-        h = volume.VolumeHelper(self.conf)
-        volume_id = uuid4()
-        self.assertRaises(InvalidImage, h.create, volume_id,
-                          image_id=image_id, lock=self.lock)
-        self.assertRaises(NotFound, h.get, volume_id)
-
     def test_create_from_nonactive_image(self):
         image_id = uuid4()
 


### PR DESCRIPTION
Added a fix for the issue where Lunr currently rejects image conversion requests for images with min_disk > 127GB. 
The check condition for the above in code has been removed as part of the fix.
Removed the corresponding unit test case as well.