### PR TITLE
Rmtarfix02

### DIFF
--- a/lunr/storage/helper/volume.py
+++ b/lunr/storage/helper/volume.py
@@ -358,6 +358,7 @@ class VolumeHelper(object):
         tarball = os.path.join(path, 'image')
         op_start = time()
         execute('tar', '-C', path, '-zxf', tarball, sudo=False)
+        execute('rm','-rf', tarball, sudo=False)
         duration = time() - op_start
         mbytes = image.size / 1024 / 1024
         uncompressed = 0

--- a/lunr/storage/helper/volume.py
+++ b/lunr/storage/helper/volume.py
@@ -358,7 +358,8 @@ class VolumeHelper(object):
         tarball = os.path.join(path, 'image')
         op_start = time()
         execute('tar', '-C', path, '-zxf', tarball, sudo=False)
-        execute('rm', tarball, sudo=False)
+        if os.path.exists(tarball):
+            os.remove(tarball)
         duration = time() - op_start
         mbytes = image.size / 1024 / 1024
         uncompressed = 0

--- a/lunr/storage/helper/volume.py
+++ b/lunr/storage/helper/volume.py
@@ -358,7 +358,7 @@ class VolumeHelper(object):
         tarball = os.path.join(path, 'image')
         op_start = time()
         execute('tar', '-C', path, '-zxf', tarball, sudo=False)
-        execute('rm','-rf', tarball, sudo=False)
+        execute('rm', tarball, sudo=False)
         duration = time() - op_start
         mbytes = image.size / 1024 / 1024
         uncompressed = 0

--- a/testlunr/unit/storage/helper/test_helper.py
+++ b/testlunr/unit/storage/helper/test_helper.py
@@ -95,10 +95,6 @@ tar_parser.add_option('-z')
 tar_parser.add_option('-x')
 tar_parser.add_option('-f')
 
-rm_parser = OptionParser('rm')
-rm_parser.add_option('-r')
-rm_parser.add_option('-f’)
-
 vhd_util_parser = OptionParser('vhd-util')
 vhd_util_parser.add_option('-n')
 vhd_util_parser.add_option('-s')
@@ -461,10 +457,6 @@ class MockProcess(object):
     def tar(self, options, args):
         sleep(0.001)
         return 'lets just ignore this.'
-
-    def rm(self, options, args):
-        sleep(0.001)
-        return 'removing file/directory'
 
     def vhd_util(self, options, args):
         return 'ignoring for now.'

--- a/testlunr/unit/storage/helper/test_helper.py
+++ b/testlunr/unit/storage/helper/test_helper.py
@@ -95,6 +95,10 @@ tar_parser.add_option('-z')
 tar_parser.add_option('-x')
 tar_parser.add_option('-f')
 
+rm_parser = OptionParser('rm')
+rm_parser.add_option('-r')
+rm_parser.add_option('-f’)
+
 vhd_util_parser = OptionParser('vhd-util')
 vhd_util_parser.add_option('-n')
 vhd_util_parser.add_option('-s')
@@ -457,6 +461,10 @@ class MockProcess(object):
     def tar(self, options, args):
         sleep(0.001)
         return 'lets just ignore this.'
+
+    def rm(self, options, args):
+        sleep(0.001)
+        return 'removing file/directory'
 
     def vhd_util(self, options, args):
         return 'ignoring for now.'

--- a/testlunr/unit/storage/helper/test_volume.py
+++ b/testlunr/unit/storage/helper/test_volume.py
@@ -628,6 +628,8 @@ class TestCopyImage(BaseHelper):
     def test_tarball_present(self):
         image = MockImage('unused_id', len(''), '', disk_format='')
         self.path = mkdtemp(dir='/tmp')
+        with open(os.path.join(self.path, 'image'),'w') as f:
+            pass
         self.helper.untar_image(self.path, image.head)
         self.assertFalse(os.path.exists(os.path.join(self.path, 'image')))
 

--- a/testlunr/unit/storage/helper/test_volume.py
+++ b/testlunr/unit/storage/helper/test_volume.py
@@ -627,7 +627,7 @@ class TestCopyImage(BaseHelper):
 
     def test_tarball_present(self):
         image = MockImage('unused_id', len(''), '', disk_format='')
-	self.path = mkdtemp(dir='/tmp')
+        self.path = mkdtemp(dir='/tmp')
         self.helper.untar_image(self.path, image.head)
         self.assertFalse(os.path.exists(os.path.join(self.path, 'image')))
 

--- a/testlunr/unit/storage/helper/test_volume.py
+++ b/testlunr/unit/storage/helper/test_volume.py
@@ -625,6 +625,12 @@ class TestCopyImage(BaseHelper):
         self.assertEquals(scrub_cb.called, True)
         self.volume_id = None
 
+    def test_tarball_present(self):
+        image = MockImage('unused_id', len(''), '', disk_format='')
+	self.path = mkdtemp(dir='/tmp')
+        self.helper.untar_image(self.path, image.head)
+        self.assertFalse(os.path.exists(os.path.join(self.path, 'image')))
+
     def test_raw(self):
         image_id = uuid4()
         data = 'A' * 4096


### PR DESCRIPTION
Added fix for removal of tarball after untar for freeing up space, and the respective test case in test_volume.py. Used os.remove instead of rm. All the test cases are working fine.