### PR TITLE
CBS-566 Products using identity v1.1 API need to migrate to v2.0 

### DIFF
--- a/lunr/storage/helper/utils/client/swift.py
+++ b/lunr/storage/helper/utils/client/swift.py
@@ -868,7 +868,7 @@ class Connection(object):
 
 def connect(conf):
     auth_url = conf.string('swift', 'auth_url',
-                           'http://localhost:8082/auth/v1.0')
+                           'http://localhost:8082/v2.0/tokens')
     user = conf.string('swift', 'user', 'test:tester')
     key = conf.string('swift', 'key', 'testing')
     region = conf.string('swift', 'region', 'USA')


### PR DESCRIPTION
JIRA url: https://jira.rax.io/browse/CBS-566
changes done were removing dependency on Identityv1.1 , adding default auth_url for swift