### PR TITLE
CBS-566 Products using identity v1.1 API need to migrate to v2.0 

### DIFF
--- a/lunr/common/config.py
+++ b/lunr/common/config.py
@@ -147,6 +147,7 @@ class LunrConfig(Config):
     lunr_api_config = '/etc/lunr/api-server.conf'
     lunr_storage_config = '/etc/lunr/storage-server.conf'
     lunr_orbit_config = '/etc/lunr/orbit.conf'
+    swift_default_auth_url = 'http://localhost:8082/v2.0/tokens'
 
     def __init__(self, values=None):
         values = values or {}

--- a/lunr/storage/helper/utils/client/swift.py
+++ b/lunr/storage/helper/utils/client/swift.py
@@ -867,8 +867,7 @@ class Connection(object):
 
 
 def connect(conf):
-    auth_url = conf.string('swift', 'auth_url',
-                           'http://localhost:8082/auth/v1.0')
+    auth_url = conf.string('swift', 'auth_url',conf.swift_default_auth_url)
     user = conf.string('swift', 'user', 'test:tester')
     key = conf.string('swift', 'key', 'testing')
     region = conf.string('swift', 'region', 'USA')

--- a/lunr/storage/helper/utils/client/swift.py
+++ b/lunr/storage/helper/utils/client/swift.py
@@ -867,7 +867,7 @@ class Connection(object):
 
 
 def connect(conf):
-    auth_url = conf.string('swift', 'auth_url',conf.swift_default_auth_url)
+    auth_url = conf.string('swift', 'auth_url', conf.swift_default_auth_url)
     user = conf.string('swift', 'user', 'test:tester')
     key = conf.string('swift', 'key', 'testing')
     region = conf.string('swift', 'region', 'USA')


### PR DESCRIPTION
JIRA url: https://jira.rax.io/browse/CBS-566
changes done were removing dependency on Identityv1.1 , adding default auth_url for swift